### PR TITLE
Add skeleton for AI-driven video generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # mvgenerate
+
+Command-line tool to generate a video from text using AI modules.
+
+## Usage
+
+```bash
+python main.py path/to/text.txt
+```

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+SCENES_DIR = os.path.join(BASE_DIR, 'scenes')
+FRAMES_DIR = os.path.join(BASE_DIR, 'frames')
+AUDIO_DIR = os.path.join(BASE_DIR, 'audio')
+VIDEO_DIR = os.path.join(BASE_DIR, 'video')
+FINAL_DIR = os.path.join(BASE_DIR, 'final')
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')

--- a/main.py
+++ b/main.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import uuid
+from typing import List
+
+from config import AUDIO_DIR, FINAL_DIR, FRAMES_DIR, SCENES_DIR, VIDEO_DIR
+from modules.image_generator import generate_images
+from modules.prompt_builder import build_prompt
+from modules.text_splitter import split_text
+from modules.tts import generate_tts
+from modules.video_maker import assemble_video, create_scene_video
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def process_text(text: str) -> str:
+    if len(text) > 5000:
+        raise ValueError("Input text exceeds 5000 characters")
+
+    scenes = split_text(text)
+    scene_file = os.path.join(SCENES_DIR, f"{uuid.uuid4()}.json")
+    os.makedirs(SCENES_DIR, exist_ok=True)
+    with open(scene_file, "w", encoding="utf-8") as f:
+        json.dump(scenes, f, ensure_ascii=False, indent=2)
+    logger.info("Scenes description saved to %s", scene_file)
+
+    scene_videos: List[str] = []
+    for idx, scene in enumerate(scenes):
+        prompt = build_prompt(scene)
+        frame_paths = generate_images(prompt, FRAMES_DIR)
+        audio_path = os.path.join(AUDIO_DIR, f"scene_{idx}.wav")
+        os.makedirs(AUDIO_DIR, exist_ok=True)
+        generate_tts(scene.get("dialogue", ""), audio_path)
+
+        video_path = os.path.join(VIDEO_DIR, f"scene_{idx}.mp4")
+        os.makedirs(VIDEO_DIR, exist_ok=True)
+        create_scene_video(frame_paths, audio_path, video_path)
+        scene_videos.append(video_path)
+
+    os.makedirs(FINAL_DIR, exist_ok=True)
+    final_path = os.path.join(FINAL_DIR, "final.mp4")
+    assemble_video(scene_videos, final_path)
+    return final_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate video from text")
+    parser.add_argument("input", help="Path to text file")
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    try:
+        final_video = process_text(text)
+        logger.info("Final video created at %s", final_video)
+    except Exception as exc:
+        logger.error("Processing failed: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/image_generator.py
+++ b/modules/image_generator.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+def generate_images(prompt: str, output_dir: str) -> List[str]:
+    """Placeholder image generation that creates empty image files."""
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, f"{uuid.uuid4()}.png")
+    try:
+        with open(path, "wb") as f:
+            f.write(b"")
+        logger.debug("Generated image for prompt '%s' at %s", prompt, path)
+        return [path]
+    except Exception as exc:
+        logger.error("Failed to generate image: %s", exc)
+        return []

--- a/modules/prompt_builder.py
+++ b/modules/prompt_builder.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def build_prompt(scene: Dict[str, str]) -> str:
+    """Build image generation prompt for a scene."""
+    try:
+        location = scene.get("location", "")
+        characters = ", ".join(scene.get("characters", [])) if isinstance(scene.get("characters"), list) else scene.get("characters", "")
+        actions = scene.get("actions", "")
+        mood = scene.get("mood", "")
+        prompt = f"{mood} scene at {location} with {characters}. Actions: {actions}."
+        logger.debug("Built prompt: %s", prompt)
+        return prompt
+    except Exception as exc:
+        logger.error("Failed to build prompt: %s", exc)
+        return ""

--- a/modules/text_splitter.py
+++ b/modules/text_splitter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Dict
+
+import openai
+
+from config import OPENAI_API_KEY
+
+logger = logging.getLogger(__name__)
+openai.api_key = OPENAI_API_KEY
+
+PROMPT_TEMPLATE = (
+    "Разбей следующий текст на логические сцены. "
+    "Верни список JSON объектов с ключами: location, characters, actions, mood, dialogue."
+)
+
+
+def split_text(text: str) -> List[Dict[str, str]]:
+    """Use LLM to split text into scene descriptions."""
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": PROMPT_TEMPLATE},
+                {"role": "user", "content": text},
+            ],
+            max_tokens=1000,
+        )
+        content = response.choices[0].message["content"]
+        scenes = json.loads(content)
+        logger.debug("Received scenes: %s", scenes)
+        return scenes
+    except Exception as exc:
+        logger.error("Failed to split text: %s", exc)
+        return []

--- a/modules/tts.py
+++ b/modules/tts.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+# Placeholder for real TTS implementation
+logger = logging.getLogger(__name__)
+
+
+def generate_tts(text: str, output_path: str) -> Optional[str]:
+    """Generate speech audio for given text and save to output_path."""
+    try:
+        # In real implementation call TTS service
+        with open(output_path, "wb") as f:
+            f.write(b"")
+        logger.debug("Generated TTS at %s", output_path)
+        return output_path
+    except Exception as exc:
+        logger.error("Failed to generate TTS: %s", exc)
+        return None

--- a/modules/video_maker.py
+++ b/modules/video_maker.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from moviepy.editor import (AudioFileClip, ImageClip, VideoFileClip,
+                            concatenate_videoclips)
+
+logger = logging.getLogger(__name__)
+
+
+def create_scene_video(frame_paths: List[str], audio_path: str, output_path: str, fps: int = 1) -> str:
+    """Create a video clip for a scene from frames and audio."""
+    clips = [ImageClip(fp).set_duration(3) for fp in frame_paths]
+    video = concatenate_videoclips(clips)
+    if audio_path:
+        audio = AudioFileClip(audio_path)
+        video = video.set_audio(audio)
+    video.write_videofile(output_path, fps=fps, verbose=False, logger=None)
+    logger.debug("Created scene video %s", output_path)
+    return output_path
+
+
+def assemble_video(scene_videos: List[str], output_path: str) -> str:
+    """Concatenate scene videos into final video."""
+    clips = [VideoFileClip(v) for v in scene_videos]
+    final_clip = concatenate_videoclips(clips)
+    final_clip.write_videofile(output_path, verbose=False, logger=None)
+    logger.debug("Assembled final video %s", output_path)
+    return output_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requirements
+openai>=1.0.0
+moviepy>=1.0.0


### PR DESCRIPTION
## Summary
- set up directories and configs
- create modules for text splitting, prompt building, image generation, TTS and video assembly
- implement main entry point
- add moviepy and openai to requirements
- update README with basic usage

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d74c76db88325acd6217d7efb0f99